### PR TITLE
fix: errors are not stored for tests

### DIFF
--- a/ltc/analyzer/models.py
+++ b/ltc/analyzer/models.py
@@ -201,41 +201,45 @@ class GraphiteVariable(models.Model):
         chart_values_max = None
         chart_values_min = None
 
-        # Build an simple html table
+        # Build a simple html table
         chart_table = '<table class="wrapped"><tbody>'
 
         # Table header
         chart_table += '<tr><th>Date</th>'
+        key = None
         for key, value in sorted(data.items()):
             chart_table += '<th>' + key + '</th>'
         chart_table += '</tr>\n'
 
         # chart rows
-        while len(data[key]) > 0:
-            timestamp = data[key][0][1]
-            chart_date = datetime.fromtimestamp(
-                timestamp
-            ).strftime('%Y-%m-%d %H:%M')
-            chart_table += '<tr><td>' + chart_date + '</td>'
+        # needs investigation:
+        # UnboundLocalError: local variable 'key' referenced before assignment
+        if key:
+            while len(data[key]) > 0:
+                timestamp = data[key][0][1]
+                chart_date = datetime.fromtimestamp(
+                    timestamp
+                ).strftime('%Y-%m-%d %H:%M')
+                chart_table += '<tr><td>' + chart_date + '</td>'
 
-            for key, value in sorted(data.items()):
-                val = value.pop(0)[0]
-                if val:
-                    this_row = round(val, 3)
-                else:
-                    this_row = 0.0
+                for key, value in sorted(data.items()):
+                    val = value.pop(0)[0]
+                    if val:
+                        this_row = round(val, 3)
+                    else:
+                        this_row = 0.0
 
-                chart_table += '<td>' + str(this_row) + '</td>'
+                    chart_table += '<td>' + str(this_row) + '</td>'
 
-                # Find min/max values.
-                if val:
-                    if not chart_values_max or chart_values_max < val:
-                        chart_values_max = val
+                    # Find min/max values.
+                    if val:
+                        if not chart_values_max or chart_values_max < val:
+                            chart_values_max = val
 
-                    if not chart_values_min or chart_values_min > val:
-                        chart_values_min = val
+                        if not chart_values_min or chart_values_min > val:
+                            chart_values_min = val
 
-            chart_table += '</tr>\n'
+                chart_table += '</tr>\n'
 
         # char footer
         chart_table += '</tbody></table>\n'

--- a/ltc/base/models.py
+++ b/ltc/base/models.py
@@ -223,7 +223,13 @@ class Project(models.Model):
         del page_parent['version']
         del page_parent['contentStatus']
         for test in last_tests:
-            test.post_to_confluence(page_parent_id, page_parent, force=force)
+            try:
+                test.post_to_confluence(page_parent_id, page_parent, force=force)
+            except Exception as e:
+                logger.warning(
+                    f'error to generate report for test #{test.id}'
+                    f'exception: {e}'
+                )
 
         return content
 

--- a/ltc/base/models.py
+++ b/ltc/base/models.py
@@ -276,7 +276,7 @@ class Test(models.Model):
             return t[1]
         return self
 
-    def analyze(self, mode=''):
+    def analyze(self):
         logger.info(
             f'Parse and generate test data: {self.id}; status: {self.status}'
         )
@@ -926,8 +926,8 @@ class TestFile(models.Model):
             )
             for chunk in chunks:
                 chunk.columns = csv_file_fields
-                df = df[~df['url'].str.contains('exclude_', na=False)]
-                df = df.append(chunk)
+                filtered = chunk[~chunk['url'].str.contains('exclude_', na=False)]
+                df = df.append(filtered)
         else:
             df = pd.read_csv(
                 self.path, index_col=0, low_memory=False

--- a/ltc/controller/models.py
+++ b/ltc/controller/models.py
@@ -200,7 +200,7 @@ class LoadGenerator(models.Model):
             [
                 'scp', '-i', ssh_key, '-r',
                 f'root@{hostname}:{logs_dir}',
-                os.path.join(test.remote_temp_path, f'{self.hostname}.log')
+                os.path.join(test.temp_path, f'{self.hostname}.log')
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE

--- a/ltc/controller/models.py
+++ b/ltc/controller/models.py
@@ -226,8 +226,6 @@ class LoadGenerator(models.Model):
                 stdin, stdout, stderr = ssh.exec_command(' ; '.join(cmds))
                 if not test.remote_temp_path:
                     continue
-                if not os.path.exists(test.remote_temp_path):
-                    continue
                 logger.info(
                     f'Deleting tmp directory from {self.hostname}: '
                     f'{test.remote_temp_path}'

--- a/ltc/controller/models.py
+++ b/ltc/controller/models.py
@@ -184,7 +184,7 @@ class LoadGenerator(models.Model):
             [
                 'scp', '-i', ssh_key, '-r',
                 f'root@{hostname}:{errors_dir}',
-                test.remote_temp_path
+                test.temp_path,
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE


### PR DESCRIPTION
We noticed two issues after the recent reactoring.

**First issue:**
No errors are stores anymore:

![Screenshot 2022-04-06 at 14 42 06](https://user-images.githubusercontent.com/1894271/161976846-470364c2-fe25-497f-8f95-32c07be43cb0.png)

From the log:
```
Using temp folder /www/ltc/temp/loadtest_1159
Using remote temp folder /tmp/loadtest_1159
```

-> "errors" were stored in  /tmp/loadtest_1159/errors/
But the "analyze_errors" method uses the temp_path aka "/www/ltc/temp/" which does not have logs


**Second issue:** 
huge csv files are failing hard to parse:
```
  File "/www/ltc/ltc/base/models.py", line 929, in parse_csv
    df = df[~df['url'].str.contains('exclude_', na=False)]
  File "/usr/lib/python3/dist-packages/pandas/core/frame.py", line 2688, in __getitem__
    return self._getitem_column(key)
...
KeyError: 'url'
```